### PR TITLE
Fixed menu disappears upon transitioning back to desktop

### DIFF
--- a/js/flaunt.js
+++ b/js/flaunt.js
@@ -35,6 +35,14 @@
 			$(this).children('.nav-arrow').toggleClass('nav-rotate');
 			
 		});
+		
+		$(window).resize(function() {
+      			var windowWidth = $(window).width();
+      			
+      			if (windowWidth > 768) {
+        			$('.nav-submenu').removeAttr("style");
+      			}
+    		});
 	    
 	});
 	

--- a/js/flaunt.min.js
+++ b/js/flaunt.min.js
@@ -9,4 +9,4 @@
 
 	Flaunt JS, stylish responsive navigations with nested click to reveal.
 */
-;(function(e){e(function(){e(".nav").append(e('<div class="nav-mobile"></div>'));e(".nav-item").has("ul").prepend('<span class="nav-click"><i class="nav-arrow"></i></span>');e(".nav-mobile").click(function(){e(".nav-list").toggle()});e(".nav-list").on("click",".nav-click",function(){e(this).siblings(".nav-submenu").toggle();e(this).children(".nav-arrow").toggleClass("nav-rotate")});e(window).resize(function(){var t=e(window).width();if(t>768){e(".nav-submenu").removeAttr("style")}})})})(jQuery)
+;(function(e){e(function(){e(".nav").append(e('<div class="nav-mobile"></div>'));e(".nav-item").has("ul").prepend('<span class="nav-click"><i class="nav-arrow"></i></span>');e(".nav-mobile").click(function(){e(".nav-list").toggle()});e(".nav-list").on("click",".nav-click",function(){e(this).siblings(".nav-submenu").toggle();e(this).children(".nav-arrow").toggleClass("nav-rotate")});e(window).resize(function(){var t=e(window).width();if(t>768){e(".nav-submenu").removeAttr("style")}})})})(jQuery);

--- a/js/flaunt.min.js
+++ b/js/flaunt.min.js
@@ -9,4 +9,4 @@
 
 	Flaunt JS, stylish responsive navigations with nested click to reveal.
 */
-;(function(e){e(function(){e(".nav").append(e('<div class="nav-mobile"></div>'));e(".nav-item").has("ul").prepend('<span class="nav-click"><i class="nav-arrow"></i></span>');e(".nav-mobile").click(function(){e(".nav-list").toggle()});e(".nav-list").on("click",".nav-click",function(){e(this).siblings(".nav-submenu").toggle();e(this).children(".nav-arrow").toggleClass("nav-rotate")})})})(jQuery);
+;(function(e){e(function(){e(".nav").append(e('<div class="nav-mobile"></div>'));e(".nav-item").has("ul").prepend('<span class="nav-click"><i class="nav-arrow"></i></span>');e(".nav-mobile").click(function(){e(".nav-list").toggle()});e(".nav-list").on("click",".nav-click",function(){e(this).siblings(".nav-submenu").toggle();e(this).children(".nav-arrow").toggleClass("nav-rotate")});e(window).resize(function(){var t=e(window).width();if(t>768){e(".nav-submenu").removeAttr("style")}})})})(jQuery)


### PR DESCRIPTION
Added a resize event on the window to check for if the window has gone back to browser size (>768). If so, remove the style:none placed on the nav-submenu so it will display normally.
